### PR TITLE
Update Switch Assistant to v1.8

### DIFF
--- a/packages/SwitchAssistant/pkgbuild.json
+++ b/packages/SwitchAssistant/pkgbuild.json
@@ -4,7 +4,7 @@
         "title": "Switch Assistant",
         "author": "ErSeraph",
         "category": "tool",
-        "version": "1.5",
+        "version": "1.8",
         "url": "https://github.com/ErSeraph/switch-assistant",
         "license": "n/a",
         "description": "An Home Assistant MQTT Connector",
@@ -20,10 +20,10 @@
             "url": "screen.png"
         },
         {
-            "url": "https://github.com/ErSeraph/switch-assistant/releases/download/v1.5/switch-ha.nro",
+            "url": "https://github.com/ErSeraph/switch-assistant/releases/download/v1.8/switch-ha.nro",
             "type": "update",
             "dest": "/switch/switch-ha/switch-ha.nro"
         }
     ],
-    "changelog": "v1.5\\nChangelog\\n\\n- Add a configurable Notifications option to disable the notifications if a custom Atmosphere isn't compatible with.\\n\\nv1.4\\nChangelog\\n\\n- Add live screen streaming to Home Assistant via RTSP.\\n- Publish a new MQTT entity with the console's RTSP stream URL for easy camera setup.\\n\\nv1.3\\nChangelog\\n\\n- Fix saved video recordings showing a green screen by excluding the notification overlay from the recording layer stack.\\n- Resolve the current game name from a bundled title database.\\n- Install the bundled title database alongside the Switch Assistant config files.\\n\\nFirst release on 1.0"
+    "changelog": "v1.8\\nChangelog\\n\\n- Add a compact binary title index to resolve game names without loading the full title database into sysmodule memory, fixing game title detection.\\n\\nv1.7\\nChangelog\\n\\n- Update the bundled title database.\\n\\nv1.6\\nChangelog\\n\\n- Improve game detection and sleep state publishing.\\n\\nv1.5\\nChangelog\\n\\n- Add a configurable Notifications option to disable notifications if a custom Atmosphere setup is not compatible.\\n\\nv1.4\\nChangelog\\n\\n- Add live screen streaming to Home Assistant via RTSP.\\n- Publish a new MQTT entity with the console's RTSP stream URL for easy camera setup.\\n\\nv1.3\\nChangelog\\n\\n- Fix saved video recordings showing a green screen by excluding the notification overlay from the recording layer stack.\\n- Resolve the current game name from a bundled title database.\\n- Install the bundled title database alongside the Switch Assistant config files.\\n\\nFirst release on 1.0"
 }


### PR DESCRIPTION
Updates the Switch Assistant package metadata to the latest GitHub release.
- Bumps version from 1.5 to 1.8
- Updates the NRO download URL to the v1.8 release asset
- Refreshes the changelog with v1.6-v1.8 entries
- Release: https://github.com/ErSeraph/switch-assistant/releases/tag/v1.8